### PR TITLE
Added a more obvious button linking back to our Github homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,9 +76,15 @@
 
         </section>
         <footer>
-            <p>Maintained by 
-                <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
-            </p>
+            <div>
+                <a
+                  href="https://github.com/saud-learning-services"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="btn_github_homepage"
+                  ><i class="fab fa-github"></i> Visit our GitHub Homepage</a
+                >
+              </div>
         </footer>
     </div>
     <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -143,3 +143,20 @@ section p {
   color: #fff;
   background-color: $primary;
 }
+
+.btn_github_homepage {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: $secondary;
+  background-color: #fff;
+  border: 2px solid $secondary;
+  padding: 6px 8px;
+  border-radius: 5px;
+  height: 25px;
+  transition: all 0.2s ease-in;
+}
+
+.btn_github_homepage:hover {
+  color: #fff;
+  background-color: $secondary;
+}


### PR DESCRIPTION
**DEFAULT**
<img width="999" alt="Screen Shot 2021-01-28 at 11 45 11 AM" src="https://user-images.githubusercontent.com/22332030/106190445-88826880-615e-11eb-8f8f-fd931c9a3bcf.png">

**HOVER**
<img width="997" alt="Screen Shot 2021-01-28 at 11 45 18 AM" src="https://user-images.githubusercontent.com/22332030/106190450-8a4c2c00-615e-11eb-91e4-7bede6d07fd4.png">
